### PR TITLE
Small typo, Adding vehicle-entity-collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@ Extra Flags used on the redstoneworld.de server.
 
 ## Flags:
 
-| Flag                     | Description                                                  | Default State |
-|--------------------------|--------------------------------------------------------------|---------------|
-| `dispense-nbt-spawneggs` | Toggles if spawn-eggs with custom NBT data will be dispensed |  true         |
+| Flag                       | Description                                                  | Default State |
+|----------------------------|--------------------------------------------------------------|---------------|
+| `dispense-nbt-spawneggs`   | Toggles if spawn-eggs with custom NBT data will be dispensed | true          |
+| `vehicle-entity-collision` | Toggle if player or mobs can collide with vehicles           | true          |
 
 ## License
 This project is licensed under the permissive [Apache 2.0 License](LICENSE).

--- a/src/main/java/de/xaver106/redworldguardflags/RedWorldguardFlags.java
+++ b/src/main/java/de/xaver106/redworldguardflags/RedWorldguardFlags.java
@@ -19,25 +19,26 @@ public final class RedWorldguardFlags extends JavaPlugin implements Listener {
     @Override
     public void onEnable() {
 
-        //register Events with Bukkit
+        // register Events with Bukkit
         getServer().getPluginManager().registerEvents(new BlockDispenseEvent(this), this);
     }
 
     @Override
     public void onLoad() {
 
-        //register WorldGuard flags
-        this.register_flag(new StateFlag("dispense-nbt-spawneggs", true)); //Registering the flag on Load (Important)
+        // register WorldGuard flags
+        this.register_flag(new StateFlag("dispense-nbt-spawneggs", true));
+        this.register_flag(new StateFlag("vehicle-entity-collision", true));
     }
 
     /**
-     * Registering a Flag with Worldguard and saving it inside the HashMap
+     * Registering a Flag with WorldGuard and saving it inside the HashMap
      *
      * @param flag The new Flag to register
      */
     @SuppressWarnings("DuplicatedCode")
     private void register_flag(Flag<?> flag) {
-        //Code modified from: https://worldguard.enginehub.org/en/latest/developer/regions/custom-flags/#registering-new-flags
+        // Code modified from: https://worldguard.enginehub.org/en/latest/developer/regions/custom-flags/#registering-new-flags
         FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
         if (this.flags == null) {
             this.flags = new HashMap<>();
@@ -66,9 +67,9 @@ public final class RedWorldguardFlags extends JavaPlugin implements Listener {
     }
 
     /**
-     * Gets flags Haspmap.
+     * Gets flags HashMap.
      *
-     * @return the flags Hashmap
+     * @return the flags HashMap
      */
     public HashMap<Class<?>, HashMap<String, Flag<?>>> getFlags() {
         return flags;

--- a/src/main/java/de/xaver106/redworldguardflags/RedWorldguardFlags.java
+++ b/src/main/java/de/xaver106/redworldguardflags/RedWorldguardFlags.java
@@ -6,6 +6,7 @@ import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
 import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
 import de.xaver106.redworldguardflags.listeners.BlockDispenseEvent;
+import de.xaver106.redworldguardflags.listeners.VehicleEntityCollisionEvent;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -21,6 +22,7 @@ public final class RedWorldguardFlags extends JavaPlugin implements Listener {
 
         // register Events with Bukkit
         getServer().getPluginManager().registerEvents(new BlockDispenseEvent(this), this);
+        getServer().getPluginManager().registerEvents(new VehicleEntityCollisionEvent(this), this);
     }
 
     @Override

--- a/src/main/java/de/xaver106/redworldguardflags/listeners/BlockDispenseEvent.java
+++ b/src/main/java/de/xaver106/redworldguardflags/listeners/BlockDispenseEvent.java
@@ -24,7 +24,7 @@ public class BlockDispenseEvent implements Listener {
     }
 
     @EventHandler
-    public void onBlockDispenseEvent(org.bukkit.event.block.BlockDispenseEvent event) {
+    public void onBlockDispense(org.bukkit.event.block.BlockDispenseEvent event) {
         // WorldGuard Query
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionQuery query = container.createQuery();

--- a/src/main/java/de/xaver106/redworldguardflags/listeners/BlockDispenseEvent.java
+++ b/src/main/java/de/xaver106/redworldguardflags/listeners/BlockDispenseEvent.java
@@ -25,7 +25,7 @@ public class BlockDispenseEvent implements Listener {
 
     @EventHandler
     public void onBlockDispenseEvent(org.bukkit.event.block.BlockDispenseEvent event) {
-        //Worldguard Query
+        // WorldGuard Query
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionQuery query = container.createQuery();
         ApplicableRegionSet set = query.getApplicableRegions(BukkitAdapter.adapt(event.getBlock().getLocation()));
@@ -33,14 +33,14 @@ public class BlockDispenseEvent implements Listener {
         // Check if the flag applies and if it is set to deny
         if (!set.testState(null, (StateFlag) plugin.getFlags().get(StateFlag.class).get("dispense-nbt-spawneggs"))) {
 
-            //test if the item is a SpawnEgg and has the EntityTag NBT tag
+            // Check if the item is a SpawnEgg and has the EntityTag NBT tag
             NBTItem nbtItem = new NBTItem(event.getItem());
             if (nbtItem.hasKey("EntityTag") && event.getItem().getType().toString().contains("SPAWN_EGG")) {
                 event.setCancelled(true);
 
-                //get BlockState to delete all illegal items inside
+                // Get BlockState to delete all illegal items inside
                 Dispenser dispenser = (Dispenser) event.getBlock().getState();
-                new BukkitRunnable() {  //Create runnable to delete all items after a tick (necessary)
+                new BukkitRunnable() {  // Create runnable to delete all items after a tick (necessary)
                     public void run() {
                         dispenser.getSnapshotInventory().remove(event.getItem().getType());
                         dispenser.update();

--- a/src/main/java/de/xaver106/redworldguardflags/listeners/VehicleEntityCollisionEvent.java
+++ b/src/main/java/de/xaver106/redworldguardflags/listeners/VehicleEntityCollisionEvent.java
@@ -1,0 +1,44 @@
+package de.xaver106.redworldguardflags.listeners;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.regions.RegionContainer;
+import com.sk89q.worldguard.protection.regions.RegionQuery;
+import de.xaver106.redworldguardflags.RedWorldguardFlags;
+import org.bukkit.entity.Mob;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+public class VehicleEntityCollisionEvent implements Listener {
+
+    private final RedWorldguardFlags plugin;
+
+    public VehicleEntityCollisionEvent(RedWorldguardFlags plugin) {
+
+        this.plugin = plugin;
+
+    }
+
+    @EventHandler
+    public void onBlockDispenseEvent(org.bukkit.event.vehicle.VehicleEntityCollisionEvent event) {
+        // WorldGuard Query
+        RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
+        RegionQuery query = container.createQuery();
+        ApplicableRegionSet set = query.getApplicableRegions(BukkitAdapter.adapt(event.getEntity().getLocation()));
+
+        // Check if the flag applies and if it is set to deny
+        if (!set.testState(null, (StateFlag) plugin.getFlags().get(StateFlag.class).get("vehicle-entity-collision"))) {
+
+            // Check if the collided entity is a player or a mob
+            if (event.getEntity() instanceof Player || event.getEntity() instanceof Mob) {
+                event.setCollisionCancelled(true);
+                event.setCancelled(true);
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/de/xaver106/redworldguardflags/listeners/VehicleEntityCollisionEvent.java
+++ b/src/main/java/de/xaver106/redworldguardflags/listeners/VehicleEntityCollisionEvent.java
@@ -23,7 +23,7 @@ public class VehicleEntityCollisionEvent implements Listener {
     }
 
     @EventHandler
-    public void onVehicleEntityCollisionEvent(org.bukkit.event.vehicle.VehicleEntityCollisionEvent event) {
+    public void onVehicleEntityCollision(org.bukkit.event.vehicle.VehicleEntityCollisionEvent event) {
         // WorldGuard Query
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionQuery query = container.createQuery();

--- a/src/main/java/de/xaver106/redworldguardflags/listeners/VehicleEntityCollisionEvent.java
+++ b/src/main/java/de/xaver106/redworldguardflags/listeners/VehicleEntityCollisionEvent.java
@@ -23,7 +23,7 @@ public class VehicleEntityCollisionEvent implements Listener {
     }
 
     @EventHandler
-    public void onBlockDispenseEvent(org.bukkit.event.vehicle.VehicleEntityCollisionEvent event) {
+    public void onVehicleEntityCollisionEvent(org.bukkit.event.vehicle.VehicleEntityCollisionEvent event) {
         // WorldGuard Query
         RegionContainer container = WorldGuard.getInstance().getPlatform().getRegionContainer();
         RegionQuery query = container.createQuery();


### PR DESCRIPTION
The default WorldGuard flag `interact` blocks only the join into the vehicles. The vehicle movement is still allowed.

The new flag has not yet been tested.